### PR TITLE
Fix GitHub Action Python version compatibility

### DIFF
--- a/.github/workflows/update-nasdaq100.yml
+++ b/.github/workflows/update-nasdaq100.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.11'
       
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Update Python version from 3.9 to 3.11 in the workflow to support pytest>=9.0.2
which requires Python >=3.10. This resolves the dependency installation error
in the automated NASDAQ-100 data update action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Python runtime from version 3.9 to 3.11 in the NASDAQ-100 data update workflow for improved performance and compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->